### PR TITLE
fix: update `typesVersion` field spec to match docs

### DIFF
--- a/src/package_json.rs
+++ b/src/package_json.rs
@@ -66,8 +66,8 @@ pub struct PackageJson {
   #[builder(default, setter(into, strip_option))]
   pub version: Option<String>,
 
-  /// Version must be parseable by node-semver, which is bundled with npm as a
-  /// dependency.
+  /// Put a description in it. It's a string.
+  /// This helps people discover your package, as it's listed in npm search.
   #[serde(default, skip_serializing_if = "Option::is_none")]
   #[builder(default, setter(into, strip_option))]
   pub description: Option<String>,
@@ -165,7 +165,7 @@ pub struct PackageJson {
     skip_serializing_if = "Option::is_none"
   )]
   #[builder(default, setter(into, strip_option))]
-  pub types_versions: Option<IndexMap<String, String>>,
+  pub types_versions: Option<IndexMap<String, TypesVersion>>,
 
   /// Specify either a single file or an array of filenames to put in place for
   /// the man program to find.
@@ -393,6 +393,20 @@ pub enum Repository {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     directory: Option<String>,
   },
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(untagged)]
+pub enum TypesVersion {
+  Path(String),
+  PathMapping(IndexMap<String, TypesVersionPaths>),
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(untagged)]
+pub enum TypesVersionPaths {
+  Path(String),
+  PathList(Vec<String>),
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]

--- a/tests/fixtures/5/package.json
+++ b/tests/fixtures/5/package.json
@@ -1,0 +1,13 @@
+{
+  "types": "dist/index.d.ts",
+  "typesVersions": {
+    "*": {
+      "one": [
+        "dist/one/index.d.ts"
+      ],
+      "two": [
+        "dist/two/index.d.ts"
+      ]
+    }
+  }
+}

--- a/tests/package_json.rs
+++ b/tests/package_json.rs
@@ -47,6 +47,28 @@ fn parse_package_json_file_with_dependencies() {
 }
 
 #[test]
+fn parse_packages_json_file_with_typescript_fields() {
+  let contents = read_to_string("./tests/fixtures/5/package.json").unwrap();
+  let package_json = PackageJson::try_from(contents).unwrap();
+
+  insta::assert_json_snapshot!(package_json, @r###"
+  {
+    "types": "dist/index.d.ts",
+    "typesVersions": {
+      "*": {
+        "one": [
+          "dist/one/index.d.ts"
+        ],
+        "two": [
+          "dist/two/index.d.ts"
+        ]
+      }
+    }
+  }
+  "###);
+}
+
+#[test]
 fn create_package_json_file_with_builder_pattern() {
   let mut additional_fields: AdditionalFields = IndexMap::new();
   additional_fields.insert("custom".into(), "value".into());


### PR DESCRIPTION
Hi! The library is throwing errors on valid documented usage of the `typesVersions` field, so this fixes that.

[Documentation so

~~(also, I added the `rustfmt.toml` file to make all future contributions respect your indent style)~~